### PR TITLE
Also use object typing for instance methods

### DIFF
--- a/lib/model.d.ts
+++ b/lib/model.d.ts
@@ -2497,9 +2497,9 @@ export abstract class Model {
    * @param options.reset Clear all previously set data values
    */
   set<K extends keyof this>(key: K, value: this[K], options?: SetOptions): this;
-  set(keys: Partial<this>, options?: SetOptions): this;
+  set(keys: object, options?: SetOptions): this;
   setAttributes<K extends keyof this>(key: K, value: this[K], options?: SetOptions): this;
-  setAttributes(keys: Partial<this>, options?: SetOptions): this;
+  setAttributes(keys: object, options?: SetOptions): this;
 
   /**
    * If changed is called with a string it will return a boolean indicating whether the value of that key in
@@ -2551,9 +2551,9 @@ export abstract class Model {
    * This is the same as calling `set` and then calling `save`.
    */
   update<K extends keyof this>(key: K, value: this[K], options?: InstanceUpdateOptions): Promise<this>;
-  update(keys: Partial<this>, options?: InstanceUpdateOptions): Promise<this>;
+  update(keys: object, options?: InstanceUpdateOptions): Promise<this>;
   updateAttributes<K extends keyof this>(key: K, value: this[K], options?: InstanceUpdateOptions): Promise<this>;
-  updateAttributes(keys: Partial<this>, options?: InstanceUpdateOptions): Promise<this>;
+  updateAttributes(keys: object, options?: InstanceUpdateOptions): Promise<this>;
 
   /**
    * Destroy the row corresponding to this instance. Depending on your setting for paranoid, the row will
@@ -2586,7 +2586,7 @@ export abstract class Model {
    *               If an array is provided, the same is true for each column.
    *               If and object is provided, each column is incremented by the value given.
    */
-  increment(fields: keyof this | (keyof this)[] | Partial<this>, options?: IncrementDecrementOptions): Promise<this>;
+  increment(fields: keyof this | (keyof this)[] | object, options?: IncrementDecrementOptions): Promise<this>;
 
   /**
    * Decrement the value of one or more columns. This is done in the database, which means it does not use
@@ -2608,7 +2608,7 @@ export abstract class Model {
    *               If an array is provided, the same is true for each column.
    *               If and object is provided, each column is decremented by the value given
    */
-  decrement(fields: keyof this | (keyof this)[] | Partial<this>, options?: IncrementDecrementOptions): Promise<this>;
+  decrement(fields: keyof this | (keyof this)[] | object, options?: IncrementDecrementOptions): Promise<this>;
 
   /**
    * Check whether all values of this and `other` Instance are the same
@@ -2624,7 +2624,7 @@ export abstract class Model {
    * Convert the instance to a JSON representation. Proxies to calling `get` with no keys. This means get all
    * values gotten from the DB, and apply all custom getters.
    */
-  toJSON(): Partial<this>;
+  toJSON(): object;
 }
 
 export default Model;

--- a/lib/model.d.ts
+++ b/lib/model.d.ts
@@ -2497,7 +2497,7 @@ export abstract class Model {
    * @param options.reset Clear all previously set data values
    */
   set<K extends keyof this>(key: K, value: this[K], options?: SetOptions): this;
-  set(keys: object, options?: SetOptions): this;
+  set(keys: Partial<this>, options?: SetOptions): this;
   setAttributes<K extends keyof this>(key: K, value: this[K], options?: SetOptions): this;
   setAttributes(keys: object, options?: SetOptions): this;
 
@@ -2586,7 +2586,7 @@ export abstract class Model {
    *               If an array is provided, the same is true for each column.
    *               If and object is provided, each column is incremented by the value given.
    */
-  increment(fields: keyof this | (keyof this)[] | object, options?: IncrementDecrementOptions): Promise<this>;
+  increment(fields: keyof this | (keyof this)[] | Partial<this>, options?: IncrementDecrementOptions): Promise<this>;
 
   /**
    * Decrement the value of one or more columns. This is done in the database, which means it does not use
@@ -2608,7 +2608,7 @@ export abstract class Model {
    *               If an array is provided, the same is true for each column.
    *               If and object is provided, each column is decremented by the value given
    */
-  decrement(fields: keyof this | (keyof this)[] | object, options?: IncrementDecrementOptions): Promise<this>;
+  decrement(fields: keyof this | (keyof this)[] | Partial<this>, options?: IncrementDecrementOptions): Promise<this>;
 
   /**
    * Check whether all values of this and `other` Instance are the same


### PR DESCRIPTION
`Partial` causes problems because it only works one level, but with `include` nested attributes may be passed.

#103 has resolved this for class methods. Here instance methods are being adjusted.