### PR TITLE
Use validator that has version in its package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "typings": "index.d.ts",
   "dependencies": {
     "@types/bluebird": "^3.5.5",
-    "@types/validator": "types/validator#76d6217b7b848ccdd1fcc2b3745eca237faafb6d"
+    "@types/validator": "types/validator#83990944fcc53bcb4b05b347c3cdfcb7aa05b3c7"
   },
   "devDependencies": {
     "tslint": "^5.4.3",


### PR DESCRIPTION
Validator#76d6217 does not have a version field in its package.json. This field is needed for npm@3 to be able to install validator (and sequelize), see https://github.com/types/validator/commit/83990944fcc53bcb4b05b347c3cdfcb7aa05b3c7