### PR TITLE
Added IncludeAll interface for eager-loading all associations

### DIFF
--- a/lib/model.d.ts
+++ b/lib/model.d.ts
@@ -325,7 +325,7 @@ export interface IncludeOptions {
   /**
    * Load further nested related models
    */
-  include?: Includeable[];
+  include?: Includeable[] | IncludeAll[];
 
   /**
    * Order include. Only available when setting `separate` to true.
@@ -336,6 +336,16 @@ export interface IncludeOptions {
    * Use sub queries. This should only be used if you know for sure the query does not result in a cartesian product.
    */
   subQuery?: boolean;
+}
+
+/**
+ * Allows for all associated models to be eagerly loaded at once
+ */
+export interface IncludeAll {
+  /**
+   * If true, all associated models will be eagerly loaded at once and included with the parent model
+   */
+  all: boolean
 }
 
 export type OrderItem =
@@ -382,11 +392,12 @@ export interface FindOptions {
 
   /**
    * A list of associations to eagerly load using a left join. Supported is either
-   * `{ include: [ Model1, Model2, ...]}` or `{ include: [{ model: Model1, as: 'Alias' }]}`.
+   * `{ include: [ Model1, Model2, ...]}`, `{ include: [{ model: Model1, as: 'Alias' }]}` or
+   * `{ include: [{ all: true }]}`.
    * If your association are set up with an `as` (eg. `X.hasMany(Y, { as: 'Z }`, you need to specify Z in
    * the as attribute when eager loading Y).
    */
-  include?: Includeable[];
+  include?: Includeable[] | IncludeAll[];
 
   /**
    * Specifies an ordering. If a string is provided, it will be escaped. Using an array, you can provide
@@ -458,7 +469,7 @@ export interface CountOptions {
   /**
    * Include options. See `find` for details
    */
-  include?: Includeable[];
+  include?: Includeable[] | IncludeAll[];
 
   /**
    * Apply COUNT(DISTINCT(col))
@@ -505,7 +516,7 @@ export interface BuildOptions {
    *
    * TODO: See set
    */
-  include?: Includeable[];
+  include?: Includeable[] | IncludeAll[];
 
 }
 

--- a/lib/model.d.ts
+++ b/lib/model.d.ts
@@ -267,7 +267,10 @@ export interface IncludeThroughOptions {
 
 }
 
-export type Includeable = Model | Association | IncludeOptions;
+/**
+ * Options for eager-loading associated models, also allowing for all associations to be loaded at once
+ */
+export type Includeable = Model | Association | IncludeOptions | { all: true };
 
 /**
  * Complex include options
@@ -325,7 +328,7 @@ export interface IncludeOptions {
   /**
    * Load further nested related models
    */
-  include?: Includeable[] | IncludeAll[];
+  include?: Includeable[];
 
   /**
    * Order include. Only available when setting `separate` to true.
@@ -336,16 +339,6 @@ export interface IncludeOptions {
    * Use sub queries. This should only be used if you know for sure the query does not result in a cartesian product.
    */
   subQuery?: boolean;
-}
-
-/**
- * Allows for all associated models to be eagerly loaded at once
- */
-export interface IncludeAll {
-  /**
-   * If true, all associated models will be eagerly loaded at once and included with the parent model
-   */
-  all: boolean
 }
 
 export type OrderItem =
@@ -397,7 +390,7 @@ export interface FindOptions {
    * If your association are set up with an `as` (eg. `X.hasMany(Y, { as: 'Z }`, you need to specify Z in
    * the as attribute when eager loading Y).
    */
-  include?: Includeable[] | IncludeAll[];
+  include?: Includeable[];
 
   /**
    * Specifies an ordering. If a string is provided, it will be escaped. Using an array, you can provide
@@ -469,7 +462,7 @@ export interface CountOptions {
   /**
    * Include options. See `find` for details
    */
-  include?: Includeable[] | IncludeAll[];
+  include?: Includeable[];
 
   /**
    * Apply COUNT(DISTINCT(col))
@@ -516,7 +509,7 @@ export interface BuildOptions {
    *
    * TODO: See set
    */
-  include?: Includeable[] | IncludeAll[];
+  include?: Includeable[];
 
 }
 

--- a/test/include.ts
+++ b/test/include.ts
@@ -14,3 +14,7 @@ MyModel.findAll({
         order: [['id', 'DESC']]
     }]
 })
+
+MyModel.findAll({
+  include: [{ all: true }]
+})


### PR DESCRIPTION
Fixes #115 

Any `IncludeAll ` array seems a bit strange, but that's what I understood sequelize expects.
Added it as a separate interface and created a `Includeable[] | IncludeAll[]` union type for the `include?` options.

Visual Studio Code sometimes seems to still suggest the other interface attributes from `IncludeOptions`, but the TypeScript compiler properly rejects e.g.

```TypeScript
include: [{
    all: true,
    include: [User]
}]
```