### PR TITLE
Add null type to WhereValue

### DIFF
--- a/lib/model.d.ts
+++ b/lib/model.d.ts
@@ -225,6 +225,7 @@ export interface WhereGeometryOptions {
 export type WhereValue =
   string // literal value
   | number // literal value
+  | null
   | WhereOperators
   | WhereAttributeHash // for JSON columns
   | Col // reference another column


### PR DESCRIPTION
Adds missing null type to WhereValue, so that strict null checks would pass, otherwise it wouldn't be a valid option.