### PR TITLE
Pass callback’s return type through to transaction result

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5779,8 +5779,8 @@ declare module sequelize {
      * @param options Transaction Options
      * @param autoCallback Callback for the transaction
      */
-    transaction(options: TransactionOptions, autoCallback: (t: Transaction) => PromiseLike<any>): SequelizePromise<any>;
-    transaction(autoCallback: (t: Transaction) => PromiseLike<any>): SequelizePromise<any>;
+    transaction<TResult>(options: TransactionOptions, autoCallback: (t: Transaction) => PromiseLike<TResult>): SequelizePromise<TResult>;
+    transaction<TResult>(autoCallback: (t: Transaction) => PromiseLike<TResult>): SequelizePromise<TResult>;
     transaction(options?: TransactionOptions): SequelizePromise<Transaction>;
 
     /**


### PR DESCRIPTION
I've been playing with this in a private fork recently and came to really like it so I wanted to share it upstream.
What I'm not completely sure about is how to merge/release this in a way that properly reflects the breaking nature of this change. Increasing the major version of the package is not really an option, I guess? Appreciate any help.