### PR TITLE
fix(blob,scope): fix bad typings

### DIFF
--- a/lib/data-types.d.ts
+++ b/lib/data-types.d.ts
@@ -49,8 +49,6 @@ export type DataType = string | AbstractDataTypeConstructor | AbstractDataType;
 export const ABSTRACT: AbstractDataTypeConstructor;
 
 interface AbstractDataTypeConstructor {
-  new (options: Object): AbstractDataType;
-  (options: Object): AbstractDataType;
   key: string;
   warn(link: string, text: string): void;
 }
@@ -362,10 +360,12 @@ export const NOW: AbstractDataTypeConstructor;
  */
 export const BLOB: BlobDataTypeConstructor;
 
+export type BlobSize = 'tiny' | 'medium' | 'long';
+
 interface BlobDataTypeConstructor extends AbstractDataTypeConstructor {
-  new (length?: number): BlobDataType;
+  new (length?: BlobSize): BlobDataType;
   new (options?: BlobDataTypeOptions): BlobDataType;
-  (length?: number): BlobDataType;
+  (length?: BlobSize): BlobDataType;
   (options?: BlobDataTypeOptions): BlobDataType;
 }
 
@@ -375,7 +375,7 @@ export interface BlobDataType extends AbstractDataType {
 }
 
 export interface BlobDataTypeOptions {
-  length?: number;
+  length?: BlobSize;
   escape?: boolean;
 }
 

--- a/lib/model.d.ts
+++ b/lib/model.d.ts
@@ -1440,6 +1440,10 @@ export interface InitOptions extends ModelOptions<any> {
   sequelize: Sequelize;
 }
 
+export interface ModelConstructor {
+  new (...args: any[]): Model;
+}
+
 export abstract class Model {
 
   /** The name of the database table */
@@ -1614,7 +1618,7 @@ export abstract class Model {
    * @return Model A reference to the model, with the scope(s) applied. Calling scope again on the returned
    *     model will clear the previous scope.
    */
-  static scope(options?: string | Array<string> | ScopeOptions | WhereAttributeHash): typeof Model;
+  static scope<M extends ModelConstructor>(this: M, options?: string | Array<string> | ScopeOptions | WhereAttributeHash): M;
 
   /**
    * Search for multiple instances.

--- a/lib/model.d.ts
+++ b/lib/model.d.ts
@@ -1440,10 +1440,6 @@ export interface InitOptions extends ModelOptions<any> {
   sequelize: Sequelize;
 }
 
-export interface ModelConstructor {
-  new (...args: any[]): Model;
-}
-
 export abstract class Model {
 
   /** The name of the database table */
@@ -1618,7 +1614,7 @@ export abstract class Model {
    * @return Model A reference to the model, with the scope(s) applied. Calling scope again on the returned
    *     model will clear the previous scope.
    */
-  static scope<M extends ModelConstructor>(this: M, options?: string | Array<string> | ScopeOptions | WhereAttributeHash): M;
+  static scope<M extends ModelCtor<any>>(this: M, options?: string | Array<string> | ScopeOptions | WhereAttributeHash): M;
 
   /**
    * Search for multiple instances.


### PR DESCRIPTION
Restrict blob types to string enums as described in docs, see http://docs.sequelizejs.com/variable/index.html#static-variable-DataTypes.

Also made sure `.scope()` returns a correct type.