### PR TITLE
fix(where): add missing fn type to wherevalue

### DIFF
--- a/lib/model.d.ts
+++ b/lib/model.d.ts
@@ -256,6 +256,7 @@ export type WhereValue =
     | WhereOperators
     | WhereAttributeHash // for JSON columns
     | Col // reference another column
+    | Fn
     | OrOperator
     | AndOperator
     | WhereGeometryOptions

--- a/test/where.ts
+++ b/test/where.ts
@@ -1,4 +1,4 @@
-import { AndOperator, Model, Op, OrOperator, Sequelize, WhereOperators, WhereOptions } from 'sequelize'
+import { AndOperator, fn, Model, Op, OrOperator, Sequelize, WhereOperators, WhereOptions } from 'sequelize'
 
 class MyModel extends Model {
     public hi: number
@@ -236,4 +236,9 @@ where = {
 // Operator symbols
 where = {
     [Op.and]: [{ id: [1, 2, 3] }, { array: { [Op.contains]: [3, 4, 5] } }],
+}
+
+// Fn as value
+where = {
+    $gt: fn('NOW'),
 }


### PR DESCRIPTION
as seen in test, this is valid syntax: 

```js
where = {
    $gt: fn('NOW'),
}
```