### PR TITLE
Fix type for max & min validators

### DIFF
--- a/lib/model.d.ts
+++ b/lib/model.d.ts
@@ -960,12 +960,12 @@ export interface ModelValidateOptions {
     /**
      * only allow values
      */
-    max?: number | { msg: string; args: number }
+    max?: number | { msg: string; args: number[] }
 
     /**
      * only allow values >= 23
      */
-    min?: number | { msg: string; args: number }
+    min?: number | { msg: string; args: number[] }
 
     /**
      * only allow arrays


### PR DESCRIPTION
Max and min validator property args takes `number[]` not `number`.  See https://github.com/sequelize/sequelize/issues/7815 .